### PR TITLE
Fixed login request to server

### DIFF
--- a/src/app/_services/authentication.service.ts
+++ b/src/app/_services/authentication.service.ts
@@ -36,7 +36,7 @@ export class AuthenticationService {
 
         const headerDict = {
           "Authorization": "Basic " + auth,
-          'Content-Type': 'application/json' 
+          'accept': 'text/plain' 
         }
         
         const requestOptions = {                                                                                                                                                                                 
@@ -44,7 +44,7 @@ export class AuthenticationService {
           withCredentials: true
         };
     
-        return this.http.get(authenticateUrl + "?email=" + username, requestOptions)
+        return this.http.get(authenticateUrl, requestOptions)
           .map(
             (response: Response) => {
                 if(response.status == 200)


### PR DESCRIPTION
Login resource was changed and the UI was not up-to-date.  The UI now does the proper request and the server doesn't return www-authenticate anymore on a failed login.  So the browser doesn't pop the login dialog anymore, which is good.  But we now need to handle the 401 code properly but clearing the login form and notifying the user of the failed loing